### PR TITLE
Remove fully qualified interpreter paths

### DIFF
--- a/irken.tcl
+++ b/irken.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/wish8.6
+#!/usr/bin/env wish8.6
 # Irken - dlowe@dlowe.net
 package require tls
 package require BWidget

--- a/irken_test.tcl
+++ b/irken_test.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 source "irken.tcl"
 


### PR DESCRIPTION
Other systems like NixOS and OpenBSD put things in different directories. This change uses `env` to find the interpreters out of PATH.